### PR TITLE
added an "enhanced" Interactive Python shell with a failover the old one

### DIFF
--- a/src/mobility/scripts/rdb.py
+++ b/src/mobility/scripts/rdb.py
@@ -63,14 +63,24 @@ if __name__ == '__main__' :
     print ('Topic data will be displayed. Press CTRL-\ to hide output.')
     readline.parse_and_bind("tab: complete")
     
+    print("Starting the enhanced Interactive Python shell")
+
+    #Systems will have an unmet dependcy run "sudo pip install ipython"
     try :
-        while True : 
-            line = raw_input('>>> ')
-            if line is not None and line != '' :
-                try :
-                    exec (line)
-                except Exception as e :
-                    print (e)
-    except EOFError as e : 
-        print ("Goodbye")
+        from IPython import embed
+        embed() # run the "enhanced" Interactive Python shell
+    except ImportError as e: #failover to Mike's line executor if missing IPython or error
+        print("Missing IPython run 'sudo pip install ipython'\n Failing over")
+        try: 
+            while True : 
+                line = raw_input('>>> ')
+                if line is not None and line != '' :
+                    try :
+                        exec (line)
+                    except Exception as e :
+                        print (e)
+        except EOFError as e : 
+            print ("Goodbye")
+
+    print ("Qapla'!")
 


### PR DESCRIPTION
Will need to have ipython installed

`sudo pip install ipython`

![carter cartersfarragut -robotics-swarmathon-cabrillo-src-mobility-scripts_012](https://user-images.githubusercontent.com/27081199/31856508-6e19b5b0-b677-11e7-93c6-69668dd85751.png)

The Failover
![carter cartersfarragut -robotics-swarmathon-cabrillo-src-mobility-scripts_013](https://user-images.githubusercontent.com/27081199/31856527-f00a91ac-b677-11e7-80cc-2004d2a42820.png)
