### PR TITLE
Added auto detection and selection of swarmies when no argument given

### DIFF
--- a/src/mobility/scripts/rdb.py
+++ b/src/mobility/scripts/rdb.py
@@ -41,10 +41,23 @@ if __name__ == '__main__' :
     quiet = False   
     
     if len(sys.argv) < 2 :
-        print ('usage:', sys.argv[0], '<rovername>')
-        exit (-1)
-    
-    rover = sys.argv[1]
+        robolist = []
+        for topic in rospy.get_published_topics():
+            if topic[1] == 'sensor_msgs/Imu':
+                robolist.append(topic[0].split('/')[1])
+        robolist=list(set(robolist))
+        if len(robolist) < 1:
+            print('\033[91m',"No Rovers Detected",'\033[0m')
+            print ('usage:', sys.argv[0], '<rovername>')
+            exit (-1)
+        else: 
+            rover = robolist[0] #in the future view subscribed topics and to pick a different rover
+            print("Detected rovers", robolist)
+            print('\033[92m',"Auto selected:",rover,'\033[0m')
+    else: 
+        rover = sys.argv[1]
+
+    print("rospy.get_name()", rospy.get_name())
 
     swarmie = Swarmie(rover)
     print ('Connected.')


### PR DESCRIPTION
Currently defaults to the first topic that belongs to a swarmie.
Future improvement view subscribed topics and to pick a different rover

Python invocation with no swarmies, 1 swarmies and 3 swarmies.
![carter cartersfarragut -robotics-swarmathon-cabrillo-src-mobility-scripts_015](https://user-images.githubusercontent.com/27081199/31866397-b06466c4-b733-11e7-9425-2418bd8aa108.png)

Python invocation with manual specified swarmie.
![carter cartersfarragut -robotics-swarmathon-cabrillo-src-mobility-scripts_016](https://user-images.githubusercontent.com/27081199/31866396-b04a6b8e-b733-11e7-969c-276cfe956779.png)

Rosrun invocations
![carter cartersfarragut -robotics-swarmathon-cabrillo_017](https://user-images.githubusercontent.com/27081199/31866395-b030bda6-b733-11e7-9c33-1235ca4e3ea7.png)


