### PR TITLE
Update camera transform and define sonar frames

### DIFF
--- a/launch/swarmie.launch
+++ b/launch/swarmie.launch
@@ -9,7 +9,7 @@
   <node name="$(arg name)_BASE2CAM"
         pkg="tf"
         type="static_transform_publisher"
-        args="0.12 -0.02 0.195 -1.570796 0 -2.04 $(arg name)/base_link $(arg name)/camera_link 100"
+        args="0.12 -0.02 0.195 -1.570796 0 -2.09 $(arg name)/base_link $(arg name)/camera_link 100"
         respawn="true"/>
   <node name="$(arg name)_BASE2SONARLEFT"
         pkg="tf"


### PR DESCRIPTION
The camera transform was angled 7 degrees too far down and translated 1 cm too far in the y-axis. This causes tag detection's relative positions in base_link to be off by as much as 5-6 cm in the x-axis (the axis pointing forward in base_link).

I also added sonar frames, although I'm not sure whether we'll find a use for them.