### PR TITLE
This actually returns nearest tag. Uses distances from camera.

### DIFF
--- a/src/mobility/src/mobility/swarmie.py
+++ b/src/mobility/src/mobility/swarmie.py
@@ -752,6 +752,9 @@ class Swarmie:
 
     def get_nearest_block_location(self):
         '''Searches the lastest block detection array and returns the nearest target block. (Home blocks are ignored.)
+
+        Nearest block will be the nearest to the camera, which should almost always be good enough.
+
         Returns:
 
         * (`geometry_msgs/Point`) The X, Y, Z location of the nearest block, or `None` if no blocks are seen.
@@ -763,10 +766,11 @@ class Swarmie:
         if len(blocks) == 0 :
             return None
 
-        loc = self.get_odom_location().get_pose()
+        # Sort blocks by their distance from the camera_link frame
         blocks = sorted(blocks, key=lambda x :
-                        math.hypot(loc.y - x.pose.pose.position.y,
-                                  loc.x - x.pose.pose.position.x))
+                        math.sqrt(x.pose.pose.position.x**2
+                                  + x.pose.pose.position.y**2
+                                  + x.pose.pose.position.z**2))
 
         nearest = blocks[0]
         self.xform.waitForTransform(self.rover_name + '/odom',


### PR DESCRIPTION
Old version was calculating distance between rover's position and each tag postions, which are in 2 different reference frames. Would almost always return the furthest tag in view.