### PR TITLE
Replace sleep()'s with wait_for_message() in swarmie.__init__()

### DIFF
--- a/src/mobility/src/mobility/swarmie.py
+++ b/src/mobility/src/mobility/swarmie.py
@@ -183,13 +183,21 @@ class Swarmie:
 
         # Wait for Odometry messages to come in.
         # Don't wait for messages on /obstacle because it's published infrequently
-        rospy.wait_for_message(rover + '/odom/filtered', Odometry, 2)
-        rospy.wait_for_message(rover + '/odom/ekf', Odometry, 2)
+        try:
+            rospy.wait_for_message(rover + '/odom/filtered', Odometry, 2)
+            rospy.wait_for_message(rover + '/odom/ekf', Odometry, 2)
+        except rospy.ROSException:
+            rospy.logwarn(self.rover_name +
+                          ': timed out waiting for filtered odometry data.')
 
         # The targets subscriber needs odom data since Carter's patch. Make sure odom data
         # exists before we get a target callback.
         rospy.Subscriber(rover + '/targets', AprilTagDetectionArray, self._targets)
-        rospy.wait_for_message(rover + '/targets', AprilTagDetectionArray, 2)
+        try:
+            rospy.wait_for_message(rover + '/targets', AprilTagDetectionArray, 2)
+        except rospy.ROSException:
+            rospy.logwarn(self.rover_name +
+                          ': timed out waiting for /targets data.')
 
         print ('Welcome', self.rover_name, 'to the world of the future.')
 


### PR DESCRIPTION
Should address `bad _targets()` callback due to uninitialized `OdomLocation` data. #55 

The `wait_for_message()` calls will raise a `ROSException` if the timeout is exceeded. Is it best to let this bubble up to whoever is creating the Swarmie instance, or catch it here in `__init__() ` silently and hope the bad_callback errors go away when the Odometry data finally comes in?

I also removed the `sleep()` after the TransformListener is created, because it's only used in `get_nearest_block_location()`, which already uses `wait_for_transform()`.