### PR TITLE
I had a couple additions after testing today

### DIFF
--- a/src/mobility/scripts/pickup.py
+++ b/src/mobility/scripts/pickup.py
@@ -53,6 +53,8 @@ def approach():
                 swarmie.set_wrist_angle(0.55)
                 rospy.sleep(1)
                 swarmie.fingers_open()
+                # Wait a moment for a block to fall out of claw
+                rospy.sleep(0.25)
         else:
             print("No legal blocks detected.")
             swarmie.wrist_up()
@@ -69,10 +71,12 @@ def approach():
 def recover():
     global swarmie 
     global claw_offset_distance
-    claw_offset_distance -= 0.01
+    claw_offset_distance -= 0.02
     print ("Missed, trying to recover.")
     try:
         swarmie.drive(-0.15, ignore=Obstacle.IS_VISION | Obstacle.IS_SONAR)
+        # Wait a moment to detect tags before possible backing up further
+        rospy.sleep(0.25)
         try:
             block = swarmie.get_nearest_block_location()
         except tf.Exception as e:
@@ -102,7 +106,7 @@ def main():
     rovername = sys.argv[1]
     swarmie = Swarmie(rovername)
     claw_offset_distance = 0.22 
-    if(simulator_running()):
+    if(swarmie.simulator_running()):
         claw_offset_distance -= 0.02
 
     print ('Waiting for camera/base_link tf to become available.')

--- a/src/mobility/src/mobility/swarmie.py
+++ b/src/mobility/src/mobility/swarmie.py
@@ -435,16 +435,19 @@ class Swarmie:
     def has_block(self):
         '''Try to determine if a block is in our grasp. 
         
-        Uses the algorithm: 
-        
-        * Raise the wrist all the way up. 
+        Uses the algorithm:
+
+         * Put wrist down to a middle position. Can help avoid any sun glare or \
+          shadows seen in wrist up position.
+        * Check if we can see a block that's close to the camera. If so, return `True`
+        * Raise the wrist all the way up.
         * Check if the center sonar is blocked at a close distance. If so, return `True`
         * Check if we can see a block that's very close. If so, return `True`
         * Return `False`
-        ''' 
+        '''
 
-        # First test: Can we see a bock that's close to the camera with the wrist middle.                
-        self.wrist_middle()
+        # First test: Can we see a bock that's close to the camera with the wrist middle.
+        self.set_wrist_angle(.55)
         rospy.sleep(1)
         blocks = self.get_latest_targets()
         blocks = sorted(blocks.detections, key=lambda x : abs(x.pose.pose.position.z))
@@ -454,7 +457,7 @@ class Swarmie:
             if abs(z_dist) < 0.18 :
                 return True 
 
-        # Second test: Can we see a bock that's close to the camera with the wirst up.                
+        # Second test: Can we see a bock that's close to the camera with the wrist up.
         self.wrist_up()
         rospy.sleep(1)
         blocks = self.get_latest_targets()


### PR DESCRIPTION
A sleep after the first backup in recover helps give the rover a chance to see any blocks in front of it. And one right after opening the claw to gently put down a undetected block helps the motion, since the wrist gets put back up right after that.

Using `set_wrist_angle(0.55)` in `has_block()` puts the wrist a little higher than `wrist_middle()` does, just to make sure the bottom part of the tag doesn't get cropped out of view.