### PR TITLE
Use node_name in rdb's swarmie so node can run alongside other tasks

### DIFF
--- a/src/mobility/scripts/rdb.py
+++ b/src/mobility/scripts/rdb.py
@@ -68,7 +68,7 @@ if __name__ == '__main__' :
     rover = rospy.get_namespace()
     print("rospy.get_namespace()", rover)
 
-    swarmie = Swarmie(tf_rover_name=rover)
+    swarmie = Swarmie(tf_rover_name=rover, node_name='rdb')
     print ('Connected.')
     
     rospy.Subscriber(rover + '/status', String, lambda msg : logHandler('/status:', msg))


### PR DESCRIPTION
This keeps the rdb node and the standard /rovername/controller node from starting with the same node name, which causes the older one to receive a shutdown request. I think it's more convenient to be able to leave rdb running while stepping through tasks individually in another terminal.