### PR TITLE
Changes the Swarmie API to use a singleton instance called 'swarmie' …

### DIFF
--- a/src/mobility/scripts/core.py
+++ b/src/mobility/scripts/core.py
@@ -21,7 +21,6 @@ def mode(msg):
 def main() :     
     global driver, heartbeat_pub, rover_mode, status_pub
     
-    task = None 
     rover_mode = 0 
     
     rospy.init_node('mobility')
@@ -45,7 +44,6 @@ def main() :
     r = rospy.Rate(10) # 10hz
     while not rospy.is_shutdown():
         if rover_mode > 1 :
-            print ('The mode is: ', mode)
             if task is None: 
                 node = roslaunch.core.Node('mobility', 'task.py', namespace=rospy.get_namespace())
                 task = launcher.launch(node)

--- a/src/mobility/scripts/rdb.py
+++ b/src/mobility/scripts/rdb.py
@@ -22,7 +22,7 @@ from mobility.srv import Core
 from mobility.msg import MoveResult
 from swarmie_msgs.msg import Obstacle 
 
-from mobility.swarmie import Swarmie 
+from mobility.swarmie import swarmie
 from ctypes import CDLL, util
 
 redraw = CDLL(util.find_library('readline')).rl_forced_update_display
@@ -55,7 +55,7 @@ if __name__ == '__main__' :
     namespace = rospy.get_namespace()
     rover = namespace.strip('/')
 
-    swarmie = Swarmie(tf_rover_name=rover, node_name='rdb')
+    swarmie.start(tf_rover_name=rover, node_name='rdb')
     print ('Connected.')
     
     rospy.Subscriber('status', String, lambda msg : logHandler('/status:', msg))

--- a/src/mobility/scripts/task.py
+++ b/src/mobility/scripts/task.py
@@ -22,7 +22,7 @@ import mobility.behavior.pickup
 import mobility.behavior.gohome
 import mobility.behavior.dropoff
 
-from mobility.swarmie import Swarmie, AbortException
+from mobility.swarmie import swarmie, AbortException
 
 '''Node that coordinates the overall robot task''' 
 
@@ -45,7 +45,6 @@ class Task :
         self.current_state = Task.STATE_IDLE 
         self.has_block = False
         self.state_publisher = rospy.Publisher('/infoLog', String, queue_size=2, latch=False)
-        self.swarmie = Swarmie(node_name='task') 
         self.status_pub = rospy.Publisher('status', String, queue_size=1, latch=True)
                         
     def print_state(self, msg):
@@ -56,7 +55,7 @@ class Task :
         
     def launch(self, prog):
         try: 
-            rval = prog(self.swarmie, has_block=self.has_block)
+            rval = prog(has_block=self.has_block)
         except SystemExit as e: 
             rval = e.code
         except AbortException as e:
@@ -141,7 +140,7 @@ class Task :
                 self.current_state = Task.STATE_GOHOME
 
 def main() :
-    # Get a manager instance. 
+    swarmie.start(node_name='task')
     taskman = Task() 
     while not rospy.is_shutdown():
         taskman.run_next() 

--- a/src/mobility/scripts/teleop_keyboard.py
+++ b/src/mobility/scripts/teleop_keyboard.py
@@ -32,14 +32,14 @@ import rospy
 import dynamic_reconfigure.client
 from sensor_msgs.msg import Joy
 from swarmie_msgs.msg import Obstacle
-from mobility.swarmie import Swarmie, TagException, HomeException, ObstacleException, PathException, AbortException
+from mobility.swarmie import swarmie, TagException, HomeException, ObstacleException, PathException, AbortException
 
 
 class Teleop(object):
     """Teleop base class."""
 
     def __init__(self, rovername):
-        self.swarmie = Swarmie(node_name='teleop_keyboard')
+        # self.swarmie = Swarmie(node_name='teleop_keyboard')
 
         self.params = {}
         self.param_client = dynamic_reconfigure.client.Client(
@@ -51,11 +51,11 @@ class Teleop(object):
 
         # Keybindings common to both derived classes:
         self.claw_bindings = {
-            'O': self.swarmie.fingers_open,
-            'U': self.swarmie.fingers_close,
-            't': self.swarmie.wrist_up,
-            'g': self.swarmie.wrist_middle,
-            'b': self.swarmie.wrist_down,
+            'O': swarmie.fingers_open,
+            'U': swarmie.fingers_close,
+            't': swarmie.wrist_up,
+            'g': swarmie.wrist_middle,
+            'b': swarmie.wrist_down,
         }
         self.param_bindings = {
             '1': ['drive_speed', 0.9],
@@ -212,12 +212,12 @@ class TeleopSwarmie(Teleop):
                         dist = self.params['drive_dist']
                         if self.drive_bindings[key] < 0:
                             dist = -dist
-                        self.swarmie.drive(dist, ignore=self.ignore_obst)
+                        swarmie.drive(dist, ignore=self.ignore_obst)
                     elif key in self.turn_bindings.keys():
                         theta = self.params['turn_theta']
                         if self.turn_bindings[key] < 0:
                             theta = -theta
-                        self.swarmie.turn(theta, ignore=self.ignore_obst)
+                        swarmie.turn(theta, ignore=self.ignore_obst)
                     elif key in self.claw_bindings.keys():
                         self.claw_bindings[key]()
                     elif key in self.param_bindings.keys():
@@ -369,6 +369,7 @@ class TeleopKey(Teleop):
 
 def main(use_swarmie=False):
     rovername = rospy.get_namespace().strip('/')
+    swarmie.start(node_name='teleop')
 
     if use_swarmie:
         teleop = TeleopSwarmie(rovername)

--- a/src/mobility/scripts/test_square.py
+++ b/src/mobility/scripts/test_square.py
@@ -9,9 +9,9 @@ import rospy
 from swarmie_msgs.msg import Obstacle
 from geometry_msgs.msg import Pose2D, Point
 
-from mobility.swarmie import Swarmie
+from mobility.swarmie import swarmie
 
-def dumb_square(swarmie, distance):
+def dumb_square(distance):
     swarmie.drive(distance, ignore=Obstacle.IS_VISION)   
     swarmie.turn(math.pi/2, ignore=Obstacle.IS_VISION)   
 
@@ -24,7 +24,7 @@ def dumb_square(swarmie, distance):
     swarmie.drive(distance, ignore=Obstacle.IS_VISION)   
     swarmie.turn(math.pi/2, ignore=Obstacle.IS_VISION)   
 
-def smart_square(swarmie, distance):    
+def smart_square(distance):
     # Compute a square based on the current heading. 
     start_pose = swarmie.get_odom_location().get_pose()
     start = Point()
@@ -50,7 +50,7 @@ def smart_square(swarmie, distance):
     
     swarmie.set_heading(start_pose.theta)
     
-def abs_square(swarmie, distance):
+def abs_square(distance):
     
     start_pose = swarmie.get_odom_location().get_pose()
     
@@ -67,7 +67,6 @@ def abs_square(swarmie, distance):
     swarmie.set_heading(start_pose.theta, ignore=-1)
 
 def main():
-    global swarmie 
     global rovername 
     
     if len(sys.argv) < 3 :
@@ -75,10 +74,10 @@ def main():
         exit (-1)
 
     rovername = sys.argv[1]
-    swarmie = Swarmie(rovername)
     distance = float(sys.argv[2])
 
     smart_square(swarmie, distance)
     
 if __name__ == '__main__' : 
+    swarmie.start(node_name='square')
     main()

--- a/src/mobility/src/mobility/behavior/dropoff.py
+++ b/src/mobility/src/mobility/behavior/dropoff.py
@@ -14,11 +14,10 @@ import tf
 from geometry_msgs.msg import Pose2D
 from swarmie_msgs.msg import Obstacle
 
-from mobility.swarmie import Swarmie
+from mobility.swarmie import swarmie
 
 def look_for_tags():
     '''Looks pi/6 in either direction, then oreient to corner if it exisits or to area with the most amount of home tags '''
-    global swarmie
     start_heading = swarmie.get_odom_location().get_pose().theta
     turnTheta = math.pi/6
     targets = []
@@ -33,7 +32,6 @@ def look_for_tags():
 
 
 def convert_to_Pose2D(t):
-    global swarmie
     swarmie.xform.waitForTransform(swarmie.rover_name + '/odom', t.pose.header.frame_id, t.pose.header.stamp, rospy.Duration(5.0))
     odom_pose = swarmie.xform.transformPose(swarmie.rover_name + '/odom', t.pose)
     quat = [odom_pose.pose.orientation.x, odom_pose.pose.orientation.y,
@@ -98,11 +96,8 @@ def find_center(tags):
     return(mid_point(*get_furthest_side_hometags_location(tags))) #this will return the middle of the 2 furthest tags on one side
 
 
-def main(s, **kwargs):
+def main(**kwargs):
     '''Dropoff throws IndexError when no tags near swarmie '''
-    global swarmie 
-    
-    swarmie = s 
     
     #move wrist down but not so down that the resource hits the ground
     swarmie.wrist_middle()
@@ -142,4 +137,5 @@ def main(s, **kwargs):
     return 0 
 
 if __name__ == '__main__' :
-    sys.exit(main(Swarmie()))
+    swarmie.start(node_name='dropoff')
+    sys.exit(main())

--- a/src/mobility/src/mobility/behavior/gohome.py
+++ b/src/mobility/src/mobility/behavior/gohome.py
@@ -30,7 +30,7 @@ from geometry_msgs.msg import Point
 from swarmie_msgs.msg import Obstacle
 from mobility.msg import MoveResult
 
-from mobility.swarmie import Swarmie, Location, PathException, HomeException, TagException, ObstacleException
+from mobility.swarmie import swarmie, Location, PathException, HomeException, TagException, ObstacleException
 from mobility.planner import Planner
 
 
@@ -38,8 +38,6 @@ GOHOME_FOUND_TAG = 1
 GOHOME_FAIL = -1
 
 def drive_straight_home_odom() :
-    global swarmie
-
     # We remember home in the Odom frame when we see it. Unlike GPS
     # there's no need to translate the location into r and theta. The
     # swarmie's drive_to function takes a point in odometry space.
@@ -75,7 +73,7 @@ def drive_home(has_block, home_loc):
 
 
 def spiral_search(has_block):
-    global planner, swarmie
+    global planner
 
     # no map waypoints
     try:
@@ -113,11 +111,10 @@ def reset_speeds():
     param_client.update_configuration(initial_config)
 
 
-def main(s, **kwargs):
-    global planner, swarmie, use_waypoints
+def main(**kwargs):
+    global planner, use_waypoints
     global initial_config, param_client
 
-    swarmie = s
     has_block = False
     if 'has_block' in kwargs : 
         has_block = kwargs['has_block']
@@ -134,7 +131,7 @@ def main(s, **kwargs):
     if not has_block:
         swarmie.print_infoLog("I don't have a block. Not avoiding targets.")
 
-    planner = Planner(swarmie)
+    planner = Planner()
 
     # Change drive and turn speeds for this behavior, and register shutdown
     # hook to reset them at exit.
@@ -203,4 +200,5 @@ def main(s, **kwargs):
     return GOHOME_FAIL
 
 if __name__ == '__main__' :
-    sys.exit(main(Swarmie(), has_block=args.has_block))
+    swarmie.start(node_name='gohome')
+    sys.exit(main(has_block=args.has_block))

--- a/src/mobility/src/mobility/behavior/init.py
+++ b/src/mobility/src/mobility/behavior/init.py
@@ -13,9 +13,9 @@ import rospy
 from swarmie_msgs.msg import Obstacle
 from mobility.msg import MoveResult
 
-from mobility.swarmie import Swarmie, Location
+from mobility.swarmie import swarmie, Location
 
-def main(swarmie, **kwargs):
+def main(**kwargs):
 
     # During a normal startup the rover will be facing the center and
     # close to the nest. But there's no guarantee where we will be if 
@@ -77,5 +77,5 @@ def main(swarmie, **kwargs):
     return 0 
 
 if __name__ == '__main__' : 
-    sys.exit(main(Swarmie()))
-    
+    swarmie.start(node_name='init')
+    sys.exit(main())

--- a/src/mobility/src/mobility/behavior/pickup.py
+++ b/src/mobility/src/mobility/behavior/pickup.py
@@ -19,12 +19,11 @@ from geometry_msgs.msg import Point
 from mobility.msg import MoveResult
 from swarmie_msgs.msg import Obstacle
 
-from mobility.swarmie import Swarmie, TagException, HomeException, ObstacleException, PathException, AbortException
+from mobility.swarmie import swarmie, TagException, HomeException, ObstacleException, PathException, AbortException
 
 '''Pickup node.''' 
 
 def approach():
-    global swarmie
     global claw_offset_distance
     print ("Attempting a pickup.")
     try:
@@ -50,7 +49,7 @@ def approach():
             if swarmie.simulator_running():
                 finger_close_angle = 0
             else:
-              finger_close_angle = 0.5
+                finger_close_angle = 0.5
               
             swarmie.set_finger_angle(finger_close_angle) #close
             rospy.sleep(1)
@@ -82,7 +81,6 @@ def approach():
     return False
 
 def recover():
-    global swarmie 
     global claw_offset_distance
     claw_offset_distance -= 0.02
     print ("Missed, trying to recover.")
@@ -107,11 +105,9 @@ def recover():
     except: 
         print("Oh no, we have an exception!")
 
-def main(s, **kwargs):
-    global swarmie 
+def main(**kwargs):
     global claw_offset_distance
     
-    swarmie = s
     claw_offset_distance = 0.24 
     if(swarmie.simulator_running()):
         claw_offset_distance -= 0.02
@@ -129,4 +125,5 @@ def main(s, **kwargs):
     return 1
 
 if __name__ == '__main__' : 
-    sys.exit(main(Swarmie()))
+    swarmie.start(node_name='pickup')
+    sys.exit(main())

--- a/src/mobility/src/mobility/behavior/search.py
+++ b/src/mobility/src/mobility/behavior/search.py
@@ -17,16 +17,14 @@ from geometry_msgs.msg import Point
 from swarmie_msgs.msg import Obstacle
 
 from mobility.planner import Planner
-from mobility.swarmie import Swarmie, TagException, HomeException, ObstacleException, PathException, AbortException, MoveResult
+from mobility.swarmie import swarmie, TagException, HomeException, ObstacleException, PathException, AbortException, MoveResult
 
 '''Searcher node.''' 
 
 def turnaround(): 
-    global swarmie
     swarmie.turn(random.gauss(math.pi/2, math.pi/4), ignore=Obstacle.IS_SONAR | Obstacle.IS_VISION)
     
 def wander():
-    global swarmie
     try :
         rospy.loginfo("Wandering...")
         swarmie.turn(random.gauss(0, math.pi/6))
@@ -41,7 +39,7 @@ def wander():
 
 
 def escape_home(detections):
-    global swarmie, planner
+    global planner
 
     print('\nGetting out of the home ring!!')
     angle, dist = planner.get_angle_and_dist_to_escape_home(detections)
@@ -56,7 +54,7 @@ def escape_home(detections):
 
 
 def handle_exit():
-    global planner, swarmie, found_tag
+    global planner, found_tag
 
     reset_speeds()
 
@@ -74,22 +72,20 @@ def reset_speeds():
 
 
 def set_search_exit_poses():
-    global swarmie
     swarmie.set_search_exit_poses()
 
 
-def main(s, **kwargs):
-    global swarmie, planner, found_tag
+def main(**kwargs):
+    global planner, found_tag
     global initial_config, param_client
 
-    swarmie = s
     found_tag = False
     SEARCH_SPEEDS = {
          'DRIVE_SPEED': 0.25,
          'TURN_SPEED': 0.7
     }
 
-    planner = Planner(swarmie)
+    planner = Planner()
 
     swarmie.fingers_open()
     swarmie.wrist_middle()
@@ -243,4 +239,5 @@ def main(s, **kwargs):
     return 1 
 
 if __name__ == '__main__' : 
-    sys.exit(main(Swarmie()))
+    swarmie.start(node_name='search')
+    sys.exit(main())

--- a/src/mobility/src/mobility/swarmie.py
+++ b/src/mobility/src/mobility/swarmie.py
@@ -115,25 +115,12 @@ class Swarmie:
     This is the Python API used to drive the rover. The API interfaces 
     with ROS topics and services to perform action and acquire sensor data. 
     ''' 
-    
-    def __init__(self, **kwargs):
+
+    def __init__(self):
         '''Constructor.
-
-        Args:
-
-        * `rover` (`string`) - Name of the rover.
-
-        Keyword arguments:
-
-        * `anonymous` (`bool`) - Launch an anonymous node. Use this for debugging nodes. 
         '''
-        if 'tf_rover_name' in kwargs :
-            self.rover_name = kwargs['tf_rover_name']
-        else:
-            self.rover_name = rospy.get_namespace()
-            
-        self.rover_name = self.rover_name.strip('/')
-           
+
+        self.rover_name = None
         self.Obstacles = 0
         self.OdomLocation = Location(None)
         self.Targets = AprilTagDetectionArray()
@@ -141,16 +128,66 @@ class Swarmie:
         self.TargetsBuffer = AprilTagDetectionArray()
         self.TargetsDictBuffer = {}
         self.targets_timeout = 3
-        
+
+        self.sm_publisher = None
+        self.status_publisher = None
+        self.info_publisher = None
+        self.mode_publisher = None
+        self.finger_publisher = None
+        self.wrist_publisher = None
+
+
+        # Numpy-ify the GridMap
+        GetMap._response_class = rospy.numpy_msg.numpy_msg(GridMap)
+
+        self.control = None
+        self._get_map = None
+        self._get_plan = None
+        self._imu_is_finished_validating = None
+        self._imu_needs_calibration =  None
+        self._start_imu_calibration = None
+        self._start_misalignment_calibration = None
+        self._start_gyro_bias_calibration = None
+        self._start_gyro_scale_calibration = None
+        self._store_imu_calibration = None
+
+        self.xform = None
+
+
+    def start(self, **kwargs):
+        """
+        Start rover services. This initializes the ROS node.
+
+        kwargs:
+
+            tf_rover_name: (str) The name of the rover used for transforms. If
+                not specified the result of rospy.get_namespace() will determine
+                the value.
+
+            node_name: (str) The name of the ROS node to be given to rospy.init().
+                If not specified the node will be called "controller".
+
+            anonymous: (bool) Tell ROS to create an anonymous node. You can read about
+                anonymous nodes here: http://wiki.ros.org/rospy/Overview/Initialization%20and%20Shutdown#Initializing_your_ROS_Node
+        """
+
+        if 'tf_rover_name' in kwargs :
+            self.rover_name = kwargs['tf_rover_name']
+        else:
+            self.rover_name = rospy.get_namespace()
+            
+        self.rover_name = self.rover_name.strip('/')
+
         # Intialize this ROS node.
         anon = False
         if 'anonymous' in kwargs : 
-            anon = True
-            
+            anon = kwargs['anonymous']
+
+        node_name = 'controller'
         if 'node_name' in kwargs :
-            rospy.init_node(kwargs['node_name'], anonymous=anon)
-        else :
-            rospy.init_node('controller', anonymous=anon)
+            node_name = kwargs['node_name']
+
+        rospy.init_node(node_name, anonymous=anon)
         
         # Create publishiers.
         self.sm_publisher = rospy.Publisher('state_machine', String, queue_size=10, latch=True)
@@ -166,9 +203,6 @@ class Swarmie:
         rospy.wait_for_service('map/get_map')
         rospy.wait_for_service('map/get_plan')
 
-        # Numpy-ify the GridMap 
-        GetMap._response_class = rospy.numpy_msg.numpy_msg(GridMap)
-        
         # Connect to services.
         self.control = rospy.ServiceProxy('control', Core)
         self._get_map = rospy.ServiceProxy('map/get_map', GetMap)
@@ -955,3 +989,14 @@ class Swarmie:
         else:
             return(False)
         
+
+#
+# Global singleton instance. No code should make a new instance
+# of swarmie. Instead it should access this instance instead as shown
+# below.
+#
+# from movility.swarmie import swarmie
+#
+# swarmie.drive()
+#
+swarmie = Swarmie()


### PR DESCRIPTION
…and changes client code to match.

This makes using swarmie simpler in client code because there's no longer a need to use a global
swarmie instance. It changes the swarmie class because we cannot initialize the ROS node inside
of the import statement. A start() function is added to swarmie that performs initialization.